### PR TITLE
Fix input redirect put

### DIFF
--- a/cmd_move.go
+++ b/cmd_move.go
@@ -23,7 +23,7 @@ func commandMove(
 		log.Fatal(tre.New(err, "get source key failed", "key", sourceKey))
 	}
 	// store value for key to target
-	commandPutPasteGenerate(kmsService, storageService, target, "put", targetKey, sourceValue)
+	commandPutPasteGenerate(kmsService, storageService, target, "put", targetKey, sourceValue, true)
 	// delete key from source
 	commandDelete(kmsService, storageService, source, sourceKey)
 }

--- a/cmd_put_paste_generate.go
+++ b/cmd_put_paste_generate.go
@@ -10,12 +10,13 @@ import (
 )
 
 func commandPutPasteGenerate(kmsService *cloudkms.Service, storageService *cloudstore.Client,
-	target profile, command, key, value string) {
+	target profile, command, key, value string, prompt bool) {
 	// check for exists
 	_, err := loadSecret(storageService, target, key)
 	if err == nil {
-		if !promptForYes(fmt.Sprintf("Are you sure to overwrite [%s] from [%s] (y/N)? ", key, target.Label)) {
+		if prompt && !promptForYes(fmt.Sprintf("Are you sure to overwrite [%s] from [%s] (y/N)? ", key, target.Label)) {
 			fmt.Println(command + " aborted")
+			return
 		}
 	}
 	encryptedValue, err := getEncryptedValue(kmsService, target, value)

--- a/cmd_put_paste_generate.go
+++ b/cmd_put_paste_generate.go
@@ -10,11 +10,11 @@ import (
 )
 
 func commandPutPasteGenerate(kmsService *cloudkms.Service, storageService *cloudstore.Client,
-	target profile, command, key, value string, prompt bool) {
+	target profile, command, key, value string, mustPrompt bool) {
 	// check for exists
 	_, err := loadSecret(storageService, target, key)
 	if err == nil {
-		if prompt && !promptForYes(fmt.Sprintf("Are you sure to overwrite [%s] from [%s] (y/N)? ", key, target.Label)) {
+		if mustPrompt && !promptForYes(fmt.Sprintf("Are you sure to overwrite [%s] from [%s] (y/N)? ", key, target.Label)) {
 			fmt.Println(command + " aborted")
 			return
 		}

--- a/cmd_put_paste_generate.go
+++ b/cmd_put_paste_generate.go
@@ -6,7 +6,7 @@ import (
 
 	cloudstore "cloud.google.com/go/storage"
 	"github.com/emicklei/tre"
-	cloudkms "google.golang.org/api/cloudkms/v1"
+	"google.golang.org/api/cloudkms/v1"
 )
 
 func commandPutPasteGenerate(kmsService *cloudkms.Service, storageService *cloudstore.Client,

--- a/cmd_template.go
+++ b/cmd_template.go
@@ -22,6 +22,7 @@ func commandTemplate(kmsService *cloudkms.Service, storageService *cloudstore.Cl
 	}
 	processor := template.New("base").Funcs(funcMap)
 	templateName := "base"
+
 	filename := flag.Arg(2)
 	if len(filename) > 0 {
 		t, err := processor.ParseFiles(filename)
@@ -31,7 +32,7 @@ func commandTemplate(kmsService *cloudkms.Service, storageService *cloudstore.Cl
 		processor = t
 		templateName = filepath.Base(filename)
 	} else {
-		templateContent := valueOrReadFrom(filename, os.Stdin)
+		templateContent := readFromStdIn()
 		t, err := processor.Parse(templateContent)
 		if err != nil {
 			log.Fatal("templating failed", err)

--- a/main.go
+++ b/main.go
@@ -19,6 +19,11 @@ import (
 
 var version = "v1.3.3"
 
+const (
+	doPrompt    = true
+	doNotPrompt = false
+)
+
 func main() {
 	flag.Parse()
 	loadConfiguration()
@@ -52,11 +57,12 @@ func main() {
 
 	case "put":
 		key := flag.Arg(2)
-		if len(flag.Arg(3)) != 0 {
-			commandPutPasteGenerate(kmsService, storageService, target, "put", key, flag.Arg(3), true)
+		value := flag.Arg(3)
+		if len(value) != 0 {
+			commandPutPasteGenerate(kmsService, storageService, target, "put", key, value, doPrompt)
 		} else {
-			value := readFromStdIn()
-			commandPutPasteGenerate(kmsService, storageService, target, "put", key, value, false)
+			value = readFromStdIn()
+			commandPutPasteGenerate(kmsService, storageService, target, "put", key, value, doNotPrompt)
 		}
 
 	case "paste":
@@ -66,18 +72,20 @@ func main() {
 		if err != nil {
 			log.Fatal(tre.New(err, "clipboard read failed", "key", key))
 		}
-		commandPutPasteGenerate(kmsService, storageService, target, "paste", key, value, true)
+		commandPutPasteGenerate(kmsService, storageService, target, "paste", key, value, doPrompt)
 
 	case "generate":
 		key := flag.Arg(2)
+		value := flag.Arg(3)
+
 		var length string
-		var prompt bool
-		if len(flag.Arg(3)) != 0 {
-			length = flag.Arg(3)
-			prompt = true
+		var mustPrompt bool
+		if len(value) != 0 {
+			length = value
+			mustPrompt = true
 		} else {
 			length = readFromStdIn()
-			prompt = false
+			mustPrompt = false
 		}
 
 		secretLength, err := strconv.Atoi(length)
@@ -88,7 +96,7 @@ func main() {
 		if err != nil {
 			log.Fatal(tre.New(err, "generate failed", "key", key, "err", err))
 		}
-		commandPutPasteGenerate(kmsService, storageService, target, "generate", key, secret, prompt)
+		commandPutPasteGenerate(kmsService, storageService, target, "generate", key, secret, mustPrompt)
 
 	case "copy":
 		key := flag.Arg(2)

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 	cloudstore "cloud.google.com/go/storage"
 	"github.com/emicklei/tre"
 	"golang.org/x/net/context"
-	cloudkms "google.golang.org/api/cloudkms/v1"
+	"google.golang.org/api/cloudkms/v1"
 )
 
 var version = "v1.3.3"
@@ -52,7 +52,12 @@ func main() {
 
 	case "put":
 		key := flag.Arg(2)
-		value := valueOrReadFrom(flag.Arg(3), os.Stdin)
+		var value string
+		if len(flag.Arg(3)) != 0 {
+			value = flag.Arg(3)
+		} else {
+			value = readFromStdIn()
+		}
 		commandPutPasteGenerate(kmsService, storageService, target, "put", key, value)
 
 	case "paste":
@@ -66,9 +71,14 @@ func main() {
 
 	case "generate":
 		key := flag.Arg(2)
-		value := valueOrReadFrom(flag.Arg(3), os.Stdin)
+		var length string
+		if len(flag.Arg(3)) != 0 {
+			length = flag.Arg(3)
+		} else {
+			length = readFromStdIn()
+		}
 
-		secretLength, err := strconv.Atoi(value)
+		secretLength, err := strconv.Atoi(length)
 		if err != nil {
 			log.Fatal(tre.New(err, "generate failed", "key", key, "err", err))
 		}

--- a/main.go
+++ b/main.go
@@ -52,13 +52,12 @@ func main() {
 
 	case "put":
 		key := flag.Arg(2)
-		var value string
 		if len(flag.Arg(3)) != 0 {
-			value = flag.Arg(3)
+			commandPutPasteGenerate(kmsService, storageService, target, "put", key, flag.Arg(3), true)
 		} else {
-			value = readFromStdIn()
+			value := readFromStdIn()
+			commandPutPasteGenerate(kmsService, storageService, target, "put", key, value, false)
 		}
-		commandPutPasteGenerate(kmsService, storageService, target, "put", key, value)
 
 	case "paste":
 		key := flag.Arg(2)
@@ -67,15 +66,18 @@ func main() {
 		if err != nil {
 			log.Fatal(tre.New(err, "clipboard read failed", "key", key))
 		}
-		commandPutPasteGenerate(kmsService, storageService, target, "paste", key, value)
+		commandPutPasteGenerate(kmsService, storageService, target, "paste", key, value, true)
 
 	case "generate":
 		key := flag.Arg(2)
 		var length string
+		var prompt bool
 		if len(flag.Arg(3)) != 0 {
 			length = flag.Arg(3)
+			prompt = true
 		} else {
 			length = readFromStdIn()
+			prompt = false
 		}
 
 		secretLength, err := strconv.Atoi(length)
@@ -86,7 +88,7 @@ func main() {
 		if err != nil {
 			log.Fatal(tre.New(err, "generate failed", "key", key, "err", err))
 		}
-		commandPutPasteGenerate(kmsService, storageService, target, "generate", key, secret)
+		commandPutPasteGenerate(kmsService, storageService, target, "generate", key, secret, prompt)
 
 	case "copy":
 		key := flag.Arg(2)

--- a/utils.go
+++ b/utils.go
@@ -30,14 +30,11 @@ func getValueByKey(kmsService *cloudkms.Service, storageService *cloudstore.Clie
 	return decryptedValue, nil
 }
 
-// valueOrReadFrom returns the value argument if not empty or the contents of the file argument if empty.
-func valueOrReadFrom(value string, file *os.File) string {
-	if len(value) != 0 {
-		return value
-	}
-	buffer, err := ioutil.ReadAll(file)
+// readFromStdIn tries to read tries to read required input from standard in
+func readFromStdIn() string {
+	buffer, err := ioutil.ReadAll(os.Stdin)
 	if err != nil {
-		log.Fatal("Error while reading from file", file, err)
+		log.Fatal("Error while reading from standard in", err)
 	}
 
 	// remove newline added to std in from command execution

--- a/utils.go
+++ b/utils.go
@@ -39,6 +39,12 @@ func valueOrReadFrom(value string, file *os.File) string {
 	if err != nil {
 		log.Fatal("Error while reading from file", file, err)
 	}
+
+	// remove newline added to std in from command execution
+	if buffer[len(buffer)-1] == '\n' {
+		buffer = buffer[:len(buffer)-1]
+	}
+
 	return string(buffer)
 }
 


### PR DESCRIPTION
This pr should solve three issues:

1. When using the put command with redirected input in the terminal the return used for kiya execution results in an extra newline in the secret value
2. When using the put command the secret was always put into kiya, even when on conformation n was entered
3. #4 

#4 was solved by not asking for conformation when reading redirected input