### PR TITLE
Added key filtering option to the list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ _Note: this will put a secret in your command history; better use copy, see belo
 
 ### List labels of stored secrets, _list_
 
-	kiya teamF1 list
+	kiya teamF1 list [|filter]
+
+Specifying a filter argument will hide any keys that don't contain the filter string.
 
 ### Fill a template, _template_
 

--- a/cmd_list.go
+++ b/cmd_list.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	cloudstore "cloud.google.com/go/storage"
@@ -13,12 +14,14 @@ import (
 	"google.golang.org/api/iterator"
 )
 
-func commandList(storageService *cloudstore.Client, target profile) {
+func commandList(storageService *cloudstore.Client, target profile, filter string) {
 	ctx := context.Background()
 	bucket := storageService.Bucket(target.Bucket)
 	query := &cloudstore.Query{}
 	it := bucket.Objects(ctx, query)
 	data := [][]string{}
+	filteredCount := 0
+
 	for {
 		next, err := it.Next()
 		if err == iterator.Done {
@@ -26,13 +29,27 @@ func commandList(storageService *cloudstore.Client, target profile) {
 		} else if err != nil {
 			log.Fatal(tre.New(err, "list failed"))
 		}
+		if filter != "" {
+			if !caseInsensitiveContains(next.Name, filter) {
+				filteredCount++
+				continue
+			}
+		}
 		data = append(data, []string{fmt.Sprintf("kiya %s copy %s", target.Label, next.Name), next.Created.Format(time.RFC822), next.Owner})
 	}
+
+	if filter != "" {
+		fmt.Printf("Showing %d key(s) matching '%s', skipped %d keys\n", len(data), filter, filteredCount)
+	}
+
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetAutoWrapText(false)
 	table.SetHeader([]string{"Copy to clipboard command", "Created", "Creator"})
-	for _, v := range data {
-		table.Append(v)
-	}
+	table.AppendBulk(data)
 	table.Render() // writes to stdout
+}
+
+func caseInsensitiveContains(key, filter string) bool {
+	key, filter = strings.ToLower(key), strings.ToLower(filter)
+	return strings.Contains(key, filter)
 }

--- a/cmd_list.go
+++ b/cmd_list.go
@@ -29,7 +29,7 @@ func commandList(storageService *cloudstore.Client, target profile, filter strin
 		} else if err != nil {
 			log.Fatal(tre.New(err, "list failed"))
 		}
-		if filter != "" {
+		if len(filter) > 0 {
 			if !caseInsensitiveContains(next.Name, filter) {
 				filteredCount++
 				continue
@@ -38,8 +38,8 @@ func commandList(storageService *cloudstore.Client, target profile, filter strin
 		data = append(data, []string{fmt.Sprintf("kiya %s copy %s", target.Label, next.Name), next.Created.Format(time.RFC822), next.Owner})
 	}
 
-	if filter != "" {
-		fmt.Printf("Showing %d key(s) matching '%s', skipped %d keys\n", len(data), filter, filteredCount)
+	if len(filter) > 0 {
+		fmt.Printf("Showing %d key(s) matching '%s', skipped %d key(s)\n", len(data), filter, filteredCount)
 	}
 
 	table := tablewriter.NewWriter(os.Stdout)

--- a/main.go
+++ b/main.go
@@ -128,7 +128,9 @@ func main() {
 		key := flag.Arg(2)
 		commandDelete(kmsService, storageService, target, key)
 	case "list":
-		commandList(storageService, target)
+		// kiya [profile] list [|filter-term]
+		filter := flag.Arg(2)
+		commandList(storageService, target, filter)
 	case "template":
 		commandTemplate(kmsService, storageService, target)
 	case "move":


### PR DESCRIPTION
This PR adds a filtering option to the list command:

`kiya <profile> list foo/bar` will limit the keys displayed to keys that contain 'foo/bar'. 