### PR TITLE
exit with non-zero code on error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN CGO_ENABLED=0 go build -ldflags "-s -w -X main.version=$version" .
 FROM alpine
 RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 COPY --from=build /go/src/github.com/kramphub/kiya /usr/bin/
-ENTRYPOINT /usr/bin/kiya
+ENTRYPOINT ["/usr/bin/kiya"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.3 AS build
+FROM golang:1.11.2-alpine AS build
 WORKDIR /go/src/github.com/kramphub/kiya/
 COPY . .
 ARG version

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func main() {
 		fmt.Println("kiya [flags] [profile] [get|put|delete|list|template|copy|paste|move|generate] [|parent/key] [|value] [|template-filename] [|secret-length]")
 		fmt.Println("    if value, template-filename or secret length is needed, but missing, it is read from stdin")
 		flag.PrintDefaults()
-		os.Exit(0)
+		os.Exit(1)
 	}
 	// Create the KMS client.
 	kmsService, err := cloudkms.New(newAuthenticatedClient())


### PR DESCRIPTION
kiya exits with 0 when the command line arguments don't match. This is a problem in a script where kiya should fail the script but doesn't.