### PR TITLE
fix: proper version variable injection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,19 @@
-FROM golang:1.25-alpine AS build
-WORKDIR /go/src/github.com/kramphub/kiya/
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS build
+WORKDIR /src
 COPY . .
-ARG version
-RUN CGO_ENABLED=0 go build -ldflags "-s -w -X main.version=$version" .
+ARG VERSION
+ARG TARGETOS
+ARG TARGETARCH
+RUN mkdir -p /out && \
+    cd /src/cmd/kiya && \
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    go build \
+      -a \
+      -ldflags "-s -w -X 'main.version=$VERSION'" \
+      -o /out/kiya
 
 FROM alpine
-RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
-COPY --from=build /go/src/github.com/kramphub/kiya /usr/bin/
+RUN apk add --no-cache ca-certificates
+COPY --from=build /out/kiya /usr/bin/kiya
+RUN chmod 755 /usr/bin/kiya
 ENTRYPOINT ["/usr/bin/kiya"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,16 @@ ARG TARGETOS
 ARG TARGETARCH
 RUN mkdir -p /out && \
     cd /src/cmd/kiya && \
-    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
-    if [ -n "$VERSION" ]; then \
-      go build -a -ldflags "-s -w -X 'main.version=$VERSION'" -o /out/kiya; \
+    if [ -n "$TARGETOS" ] && [ -n "$TARGETARCH" ]; then \
+      CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
+        -a \
+        -ldflags "-s -w -X 'main.version=$VERSION'" \
+        -o /out/kiya; \
     else \
-      go build -a -ldflags "-s -w" -o /out/kiya; \
+      CGO_ENABLED=0 go build \
+        -a \
+        -ldflags "-s -w -X 'main.version=$VERSION'" \
+        -o /out/kiya; \
     fi
 
 FROM alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,17 @@
 FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS build
 WORKDIR /src
 COPY . .
-ARG VERSION
+ARG VERSION=dev
 ARG TARGETOS
 ARG TARGETARCH
 RUN mkdir -p /out && \
     cd /src/cmd/kiya && \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
-    go build \
-      -a \
-      -ldflags "-s -w -X 'main.version=$VERSION'" \
-      -o /out/kiya
+    if [ -n "$VERSION" ]; then \
+      go build -a -ldflags "-s -w -X 'main.version=$VERSION'" -o /out/kiya; \
+    else \
+      go build -a -ldflags "-s -w" -o /out/kiya; \
+    fi
 
 FROM alpine
 RUN apk add --no-cache ca-certificates

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ releasegen:
 	docker run \
 		--volume "$(CURDIR):/go/src/github.com/kramphub/kiya" \
 		--workdir "/go/src/github.com/kramphub/kiya" \
-		golang:1.14 \
+		golang:1.25 \
 		bash -x etc/bin/releasegen.sh
 
 # go get github.com/aktau/github-release
@@ -38,3 +38,8 @@ uploadrelease:
 		--tag $(shell git describe --abbrev=0 --tags) \
 		--name "kiya-Darwin-x86_64" \
 		--file release/kiya-Darwin-x86_64
+
+# PLATFORM=linux/arm64 IMAGE=github-kramphub-kiya make docker-build
+.PHONY: docker-build
+docker-build:
+	@etc/bin/docker-build.sh

--- a/cmd/kiya/main.go
+++ b/cmd/kiya/main.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"os"
 	"strconv"
-	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/keyvault/azsecrets"
@@ -23,7 +22,7 @@ import (
 	"google.golang.org/api/option"
 )
 
-var version = "build-" + time.Now().String()
+var version = "dev"
 
 const (
 	doPrompt    = true

--- a/etc/bin/docker-build.sh
+++ b/etc/bin/docker-build.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -eu
+
+PLATFORM="${PLATFORM:-linux/amd64}"
+IMAGE="${IMAGE:-github-kramphub-kiya}"
+
+LATEST_TAG="$(git tag -l --points-at HEAD | head -n1 || true)"
+if [ -z "$LATEST_TAG" ]; then
+  LATEST_TAG="$(git describe --abbrev=0 --tags 2>/dev/null || true)"
+fi
+
+VERSION="${LATEST_TAG#v}"
+if [ -z "$VERSION" ]; then
+  VERSION="dev"
+fi
+
+BUILD_TIME="$(date -u +"%Y%m%dT%H%M%SZ")"
+COMMIT="$(git rev-parse --short HEAD)"
+FULL_VERSION="${VERSION}+${COMMIT}.${BUILD_TIME}"
+
+echo "Building image $IMAGE:$VERSION"
+echo "Embedded version: $FULL_VERSION"
+
+docker buildx build \
+  --no-cache \
+  --platform "$PLATFORM" \
+  --build-arg VERSION="$FULL_VERSION" \
+  -t "$IMAGE:$VERSION" \
+  --progress=plain \
+  --load .

--- a/etc/bin/releasegen.sh
+++ b/etc/bin/releasegen.sh
@@ -26,6 +26,19 @@ rm -rf "${BASE_DIR}"
 
 SRCS=$(find . -type f -name "*.go" -maxdepth 1 | grep -v "test")
 
+LATEST_TAG="$(git tag -l --points-at HEAD | head -n1 || true)"
+if [ -z "${LATEST_TAG}" ]; then
+  LATEST_TAG="$(git describe --abbrev=0 --tags 2>/dev/null || true)"
+fi
+VERSION="${LATEST_TAG#v}"
+if [ -z "${VERSION}" ]; then
+  VERSION="dev"
+fi
+BUILD_TIME="$(date -u +"%Y%m%dT%H%M%SZ")"
+COMMIT="$(git rev-parse --short HEAD)"
+FULL_VERSION="${VERSION}+${COMMIT}.${BUILD_TIME}"
+echo "Embedded version: $${FULL_VERSION}"
+
 for os in Darwin Linux Windows; do
   for arch in x86_64; do
     dir="${BASE_DIR}/${os}/${arch}/kiya"
@@ -35,13 +48,13 @@ for os in Darwin Linux Windows; do
     echo GOOS=$(goos "${os}") GOARCH=$(goarch "${arch}") \
       go build \
       -a \
-      -ldflags "-X 'main.version=$(git tag -l --points-at HEAD)'" \
+      -ldflags "-X main.version=${FULL_VERSION}" \
       -o "${dir}/bin/kiya" \
       ${SRCS}
     GOOS=$(goos "${os}") GOARCH=$(goarch "${arch}") \
       go build \
       -a \
-      -ldflags "-X 'main.version=$(git tag -l --points-at HEAD)'" \
+      -ldflags "-X main.version=${FULL_VERSION}" \
       -o "${dir}/bin/kiya" \
       ${SRCS}
     tar -C "${tar_context_dir}" -cvzf "${BASE_DIR}/kiya-${os}-${arch}.tar.gz" "${tar_dir}"


### PR DESCRIPTION
The linker could not replace the version variable because it was not a constant (`build-" + time.Now().String()`). 
As a result, the `--version` flag always printed the application’s start date and time, not the build time.

This commit updates releasegen.sh to provide version information, including commit hash and build time. E.g. `kiya version 1.18.0+e89a3e1.20260402T120409Z`. 
But we can also keep it more simple, like `kiya version 1.18`?

The Dockerfile has also been updated, and a convenience script for building the image has been added.