### PR TITLE
chore: address vulnerabilities in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS build
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine3.23 AS build
 WORKDIR /src
 COPY . .
 ARG VERSION=dev
@@ -18,8 +18,8 @@ RUN mkdir -p /out && \
         -o /out/kiya; \
     fi
 
-FROM alpine
-RUN apk add --no-cache ca-certificates
+FROM alpine:3.23
+RUN apk add --no-cache ca-certificates && apk upgrade --no-cache
 COPY --from=build /out/kiya /usr/bin/kiya
 RUN chmod 755 /usr/bin/kiya
 ENTRYPOINT ["/usr/bin/kiya"]


### PR DESCRIPTION
This commit updates the Dockerfile to address vulnerabilities in the resulting Docker image by pinning the base image to the minor version `alpine:3.23` and ensuring all packages are upgraded to their latest versions during the build process.

Pinning to the minor version strikes a balance between stability and security. It allows for automatic updates to patch versions, which include security fixes, while avoiding potential breaking changes introduced in major version updates. This approach ensures that the image remains secure without compromising compatibility.

The following vulnerabilities were mitigated:
- CVE-2026-22184: https://security.alpinelinux.org/vuln/CVE-2026-22184
- CVE-2026-27171: https://security.alpinelinux.org/vuln/CVE-2026-27171

By addressing these issues, the Docker image is (for now) free of known vulnerabilities.

I didn't "tag" it as `fix:` because it doesn't change the code of `kiya` itself.